### PR TITLE
Cleanup map conversion

### DIFF
--- a/deinterfacer_test.go
+++ b/deinterfacer_test.go
@@ -3,17 +3,19 @@ package junocfg
 // https://golang.org/pkg/testing/
 
 import (
-	//"bytes"
 	"encoding/json"
+	"reflect"
+	//"bytes"
+
 	"testing"
 )
 
 var deinterfacerTests = []struct {
 	in  map[string]interface{}
-	out string
+	out map[string]interface{}
 }{
 	{
-		map[string]interface{}{
+		in: map[string]interface{}{
 			"a": "a",
 			"b": []string{"b1", "b2", "b3", "b4"},
 			"c": map[interface{}]interface{}{
@@ -36,20 +38,71 @@ var deinterfacerTests = []struct {
 				"eb": "eb",
 				"ec": "ec",
 			},
+			"f": []int{1, 2, 3, 4},
 		},
-		`{"a":"a","b":["b1","b2","b3","b4"],"c":{"ca":"ca","cb":["cb1","cb2",{"cb3a":"cb3aa"},"cb4",{"cb5a":"cb5aa"}]},"d":"a","e":{"ea":"ea","eb":"eb","ec":"ec"}}`,
+		out: map[string]interface{}{
+			"a": "a",
+			"b": []interface{}{"b1", "b2", "b3", "b4"},
+			"c": map[string]interface{}{
+				"ca": "ca",
+				"cb": []interface{}{
+					"cb1",
+					"cb2",
+					map[string]interface{}{
+						"cb3a": "cb3aa",
+					},
+					"cb4",
+					map[string]interface{}{
+						"cb5a": "cb5aa",
+					},
+				},
+			},
+			"d": "a",
+			"e": map[string]interface{}{
+				"ea": "ea",
+				"eb": "eb",
+				"ec": "ec",
+			},
+			"f": []interface{}{1, 2, 3, 4},
+		},
+	},
+	{in: nil, out: map[string]interface{}{}},
+	{in: map[string]interface{}{}, out: map[string]interface{}{}},
+	{
+		in: map[string]interface{}{
+			"key_0": map[int]int{
+				1:  1,
+				2:  3,
+				5:  8,
+				13: 21,
+			},
+		},
+		out: map[string]interface{}{
+			"key_0": map[string]interface{}{
+				"1":  1,
+				"2":  3,
+				"5":  8,
+				"13": 21,
+			},
+		},
 	},
 }
 
 func Test_deinterfacer(t *testing.T) {
 	for i, tst := range deinterfacerTests {
-		out, err := deinterface(tst.in)
-		if err != nil {
-			t.Errorf("For %d deinterface error %v", i, err)
+		out := deinterface(tst.in)
+		if !reflect.DeepEqual(tst.out, out) {
+			t.Errorf("For %d \nexpected %#v \ngot %#v", i, tst.out, out)
 		}
-		outStr, err := json.Marshal(out)
-		if string(outStr) != tst.out {
-			t.Errorf("For %d expected %v got %v", i, tst.out, string(outStr))
+	}
+}
+
+func Test_deinterfacereMarshallable(t *testing.T) {
+	for i, tst := range deinterfacerTests {
+		out := deinterface(tst.in)
+		_, err := json.Marshal(out)
+		if err != nil {
+			t.Errorf("For %d got error while marshalling %s", i, err)
 		}
 	}
 }

--- a/map.go
+++ b/map.go
@@ -39,9 +39,6 @@ func Items2Map(items ItemArray) (map[string]interface{}, error) {
 			return nil, err
 		}
 	}
-	result, err := deinterface(dst)
-	if err != nil {
-		return nil, err
-	}
+	result := deinterface(dst)
 	return result, nil
 }


### PR DESCRIPTION
Current impl support maps with any value type (not only string or interface{}).
Implemantation can be cleaned up more by using simple type switch,
though, will be suitable only for yaml unmarshalling results.

A huge THANK YOU for Minsk Go meetups!